### PR TITLE
Add missing ifs around warnings

### DIFF
--- a/src/ts/RevlogGraphs.svelte
+++ b/src/ts/RevlogGraphs.svelte
@@ -359,7 +359,9 @@
         </div>
         <span>Total: {time_machine_added}</span>
         <p>Shows your card type counts for a given date</p>
-        <Warning>May be inaccurate while "all history" is not selected.</Warning>
+        {#if truncated}
+            <Warning>May be inaccurate while "all history" is not selected.</Warning>
+        {/if}
     </GraphContainer>
     <GraphContainer>
         <h1>Review Interval Time Machine</h1>
@@ -375,7 +377,9 @@
             </span>
         </label>
         <p>Shows your review intervals for a given date</p>
-        <Warning>May be inaccurate while "all history" is not selected.</Warning>
+        {#if truncated}
+            <Warning>May be inaccurate while "all history" is not selected.</Warning>
+        {/if}
     </GraphContainer>
 </GraphCategory>
 


### PR DESCRIPTION
Fixes #16 by adding the ifs around warnings that were missing from the card counts and review interval time machine stats but present for the other stats