### PR TITLE
Feature/lapse average burden

### DIFF
--- a/locale/en_GB.ftl
+++ b/locale/en_GB.ftl
@@ -178,9 +178,13 @@ highest-repetition-count = Most Repetitions
 repetition-count = Repetitions
 total-repetitions = Total Repetitions
 
-repetition-load = Repetition Load
+repetition-load = Repetition Total Load
 repetition-load-help = 
     This graph shows the sum of "1 / interval" for all cards which have the given number of repetitions.
+
+repetition-avg-load = Repetition Average Load
+repetition-avg-help =
+    This graph shows the average of "1 / interval" for all cards which have the given number of repetitions.
 
 repetition-distribution = Repetition Distribution
 repetition-distribution-help = 

--- a/src/ts/CardDataPies.svelte
+++ b/src/ts/CardDataPies.svelte
@@ -21,8 +21,16 @@
     export let cardData: CardData[] | null
 
     $: true_zero_inclusive = $zero_inclusive || $graph_mode == "Bar"
-    $: ({ lapses, repetitions, lapses_burden, repetitions_burden, target_R_days } = catchErrors(
-        () => calculateCardDataPies(cardData ?? [], $include_suspended, true_zero_inclusive)
+    $: ({
+        lapses,
+        repetitions,
+        lapses_burden,
+        lapses_avg_burden,
+        repetitions_burden,
+        repetitions_avg_burden,
+        target_R_days,
+    } = catchErrors(() =>
+        calculateCardDataPies(cardData ?? [], $include_suspended, true_zero_inclusive)
     ))
 
     let lapse_last = 7
@@ -39,6 +47,26 @@
         <h1>{i18n("lapse-load")}</h1>
         <IntervalGraph
             intervals={lapses_burden}
+            bind:steps={lapse_steps}
+            bind:last={lapse_last}
+            pieInfo={{
+                totalDescriptor: i18n("load"),
+                countDescriptor: i18n("highest-lapse-count"),
+                legend_left: i18n("lapse-count"),
+                legend_right: i18n("card-load"),
+                spectrumFrom: "#bd3f09",
+                spectrumTo: "#612207",
+            }}
+            zero_inclusive_option
+        ></IntervalGraph>
+        <p>
+            {i18n("lapse-load-help")}
+        </p>
+    </GraphContainer>
+    <GraphContainer>
+        <h1>{i18n("lapse-average-load")}</h1>
+        <IntervalGraph
+            intervals={lapses_avg_burden}
             bind:steps={lapse_steps}
             bind:last={lapse_last}
             pieInfo={{
@@ -101,6 +129,25 @@
         <h1>{i18n("repetition-load")}</h1>
         <IntervalGraph
             intervals={repetitions_burden}
+            bind:steps={repetitions_steps}
+            bind:last={repetitions_last}
+            pieInfo={{
+                totalDescriptor: i18n("load"),
+                countDescriptor: i18n("highest-repetition-count"),
+                legend_left: i18n("repetition-count"),
+                legend_right: i18n("card-load"),
+                spectrumFrom: "#5ca7f7",
+                spectrumTo: "#0b4f99",
+            }}
+        />
+        <p>
+            {i18n("repetition-load-help")}
+        </p>
+    </GraphContainer>
+    <GraphContainer>
+        <h1>{i18n("repetition-avg-load")}</h1>
+        <IntervalGraph
+            intervals={repetitions_avg_burden}
             bind:steps={repetitions_steps}
             bind:last={repetitions_last}
             pieInfo={{

--- a/src/ts/CardDataPies.svelte
+++ b/src/ts/CardDataPies.svelte
@@ -28,6 +28,7 @@
         lapses_avg_burden,
         repetitions_burden,
         repetitions_avg_burden,
+        total_burden,
         target_R_days,
     } = catchErrors(() =>
         calculateCardDataPies(cardData ?? [], $include_suspended, true_zero_inclusive)
@@ -38,6 +39,9 @@
 
     let repetitions_last = 21
     let repetitions_steps = 7
+
+    let normalize_burden = false
+    let cumulative_burden = false
 
     $: $target_R_days_values = $data ? target_R_days : []
 </script>
@@ -128,7 +132,12 @@
     <GraphContainer>
         <h1>{i18n("repetition-load")}</h1>
         <IntervalGraph
-            intervals={repetitions_burden}
+            intervals={repetitions_burden
+                .map((burden) => (normalize_burden ? (burden / total_burden) * 100 : burden))
+                .map((burden, i, last_mapepd_burden) =>
+                    cumulative_burden ? _.sum(last_mapepd_burden.slice(1, i)) + burden : burden
+                )}
+            average={normalize_burden}
             bind:steps={repetitions_steps}
             bind:last={repetitions_last}
             pieInfo={{
@@ -143,6 +152,14 @@
         <p>
             {i18n("repetition-load-help")}
         </p>
+        <label>
+            <input type="checkbox" bind:checked={normalize_burden} />
+            {i18n("as-ratio")}
+        </label>
+        <label>
+            <input type="checkbox" bind:checked={cumulative_burden} />
+            {i18n("cumulative")}
+        </label>
     </GraphContainer>
     <GraphContainer>
         <h1>{i18n("repetition-avg-load")}</h1>

--- a/src/ts/CardDataPies.svelte
+++ b/src/ts/CardDataPies.svelte
@@ -171,7 +171,7 @@
                 .map((burden, i, last_arr) =>
                     cumulative_burden ? _.sum(last_arr.slice(1, i)) + burden : burden
                 )}
-            average={cumulative_burden}
+            average
             bind:steps={repetitions_steps}
             bind:last={repetitions_last}
             pieInfo={{
@@ -198,7 +198,12 @@
     <GraphContainer>
         <h1>{i18n("repetition-distribution")}</h1>
         <IntervalGraph
-            intervals={repetitions}
+            intervals={repetitions
+                .map((card) => (normalize_burden ? (card / _.sum(repetitions)) * 100 : card))
+                .map((card, i, last_arr) =>
+                    cumulative_burden ? _.sum(last_arr.slice(1, i)) + card : card
+                )}
+            average={cumulative_burden}
             bind:steps={repetitions_steps}
             bind:last={repetitions_last}
             pieInfo={{
@@ -210,6 +215,14 @@
             }}
         />
         <p>{i18n("repetition-distribution-help")}</p>
+        <label>
+            <input type="checkbox" bind:checked={normalize_burden} />
+            {i18n("as-ratio")}
+        </label>
+        <label>
+            <input type="checkbox" bind:checked={cumulative_burden} />
+            {i18n("cumulative")}
+        </label>
     </GraphContainer>
     <GraphContainer>
         <h1>{i18n("repetition-total")}</h1>

--- a/src/ts/CardDataPies.svelte
+++ b/src/ts/CardDataPies.svelte
@@ -134,10 +134,10 @@
         <IntervalGraph
             intervals={repetitions_burden
                 .map((burden) => (normalize_burden ? (burden / total_burden) * 100 : burden))
-                .map((burden, i, last_mapepd_burden) =>
-                    cumulative_burden ? _.sum(last_mapepd_burden.slice(1, i)) + burden : burden
+                .map((burden, i, last_arr) =>
+                    cumulative_burden ? _.sum(last_arr.slice(1, i)) + burden : burden
                 )}
-            average={normalize_burden}
+            average={cumulative_burden}
             bind:steps={repetitions_steps}
             bind:last={repetitions_last}
             pieInfo={{
@@ -164,7 +164,14 @@
     <GraphContainer>
         <h1>{i18n("repetition-avg-load")}</h1>
         <IntervalGraph
-            intervals={repetitions_avg_burden}
+            intervals={repetitions_avg_burden
+                .map((burden) =>
+                    normalize_burden ? (burden / _.sum(repetitions_avg_burden)) * 100 : burden
+                )
+                .map((burden, i, last_arr) =>
+                    cumulative_burden ? _.sum(last_arr.slice(1, i)) + burden : burden
+                )}
+            average={cumulative_burden}
             bind:steps={repetitions_steps}
             bind:last={repetitions_last}
             pieInfo={{
@@ -179,6 +186,14 @@
         <p>
             {i18n("repetition-load-help")}
         </p>
+        <label>
+            <input type="checkbox" bind:checked={normalize_burden} />
+            {i18n("as-ratio")}
+        </label>
+        <label>
+            <input type="checkbox" bind:checked={cumulative_burden} />
+            {i18n("cumulative")}
+        </label>
     </GraphContainer>
     <GraphContainer>
         <h1>{i18n("repetition-distribution")}</h1>

--- a/src/ts/CardDataPies.ts
+++ b/src/ts/CardDataPies.ts
@@ -13,6 +13,7 @@ export function calculateCardDataPies(
     let lapses_avg_burden: number[] = []
     let repetitions_burden: number[] = []
     let repetitions_avg_burden: number[] = []
+    let total_burden = 0
     let target_R_days: number[] = []
     const days_elapsed = SSEother.days_elapsed
 
@@ -23,6 +24,7 @@ export function calculateCardDataPies(
                 repetitions[card.reps] = (repetitions[card.reps] ?? 0) + 1
 
                 const burden = card.ivl > 0 ? 1 / card.ivl : 1
+                total_burden += burden
 
                 lapses_burden[card.lapses] = (lapses_burden[card.lapses] ?? 0) + burden
                 const old_lapses_avg_burden = lapses_avg_burden[card.reps] ?? 0
@@ -55,6 +57,17 @@ export function calculateCardDataPies(
         delete lapses_burden[0]
     }
 
+    const arraysToSanitize = [
+        lapses,
+        repetitions,
+        lapses_burden,
+        lapses_avg_burden,
+        repetitions_burden,
+        repetitions_avg_burden,
+    ]
+
+    arraysToSanitize.forEach(sanitize)
+
     return {
         lapses,
         repetitions,
@@ -62,6 +75,17 @@ export function calculateCardDataPies(
         lapses_avg_burden,
         repetitions_burden,
         repetitions_avg_burden,
+        total_burden,
         target_R_days,
     }
+}
+
+function sanitize(arr: number[]): number[] {
+    let maxIndex = arr.length - 1
+    for (let i = 0; i <= maxIndex; i++) {
+        if (arr[i] === undefined) {
+            arr[i] = 0
+        }
+    }
+    return arr
 }

--- a/src/ts/CardDataPies.ts
+++ b/src/ts/CardDataPies.ts
@@ -26,8 +26,8 @@ export function calculateCardDataPies(
 
                 lapses_burden[card.lapses] = (lapses_burden[card.lapses] ?? 0) + burden
                 const old_lapses_avg_burden = lapses_avg_burden[card.reps] ?? 0
-                lapses_avg_burden[card.reps] =
-                    old_lapses_avg_burden + (burden - old_lapses_avg_burden) / lapses[card.reps]
+                lapses_avg_burden[card.lapses] =
+                    old_lapses_avg_burden + (burden - old_lapses_avg_burden) / lapses[card.lapses]
 
                 repetitions_burden[card.reps] = (repetitions_burden[card.reps] ?? 0) + burden
                 const old_repetitions_avg_burden = repetitions_avg_burden[card.reps] ?? 0

--- a/src/ts/CardDataPies.ts
+++ b/src/ts/CardDataPies.ts
@@ -10,7 +10,9 @@ export function calculateCardDataPies(
     let lapses: number[] = []
     let repetitions: number[] = []
     let lapses_burden: number[] = []
+    let lapses_avg_burden: number[] = []
     let repetitions_burden: number[] = []
+    let repetitions_avg_burden: number[] = []
     let target_R_days: number[] = []
     const days_elapsed = SSEother.days_elapsed
 
@@ -23,7 +25,15 @@ export function calculateCardDataPies(
                 const burden = card.ivl > 0 ? 1 / card.ivl : 1
 
                 lapses_burden[card.lapses] = (lapses_burden[card.lapses] ?? 0) + burden
+                const old_lapses_avg_burden = repetitions_avg_burden[card.reps] ?? 0
+                lapses_avg_burden[card.reps] =
+                    old_lapses_avg_burden + (old_lapses_avg_burden - burden) / lapses[card.reps]
+
                 repetitions_burden[card.reps] = (repetitions_burden[card.reps] ?? 0) + burden
+                const old_repetitions_avg_burden = repetitions_avg_burden[card.reps] ?? 0
+                repetitions_avg_burden[card.reps] =
+                    old_repetitions_avg_burden +
+                    (old_repetitions_avg_burden - burden) / repetitions[card.reps]
 
                 const stability = JSON.parse(card.data).s
                 if (stability && card.ivl > 0 && card.type == 2 && card.queue > 0) {
@@ -45,5 +55,13 @@ export function calculateCardDataPies(
         delete lapses_burden[0]
     }
 
-    return { lapses, repetitions, lapses_burden, repetitions_burden, target_R_days }
+    return {
+        lapses,
+        repetitions,
+        lapses_burden,
+        lapses_avg_burden,
+        repetitions_burden,
+        repetitions_avg_burden,
+        target_R_days,
+    }
 }

--- a/src/ts/CardDataPies.ts
+++ b/src/ts/CardDataPies.ts
@@ -25,7 +25,7 @@ export function calculateCardDataPies(
                 const burden = card.ivl > 0 ? 1 / card.ivl : 1
 
                 lapses_burden[card.lapses] = (lapses_burden[card.lapses] ?? 0) + burden
-                const old_lapses_avg_burden = repetitions_avg_burden[card.reps] ?? 0
+                const old_lapses_avg_burden = lapses_avg_burden[card.reps] ?? 0
                 lapses_avg_burden[card.reps] =
                     old_lapses_avg_burden + (burden - old_lapses_avg_burden) / lapses[card.reps]
 

--- a/src/ts/CardDataPies.ts
+++ b/src/ts/CardDataPies.ts
@@ -27,13 +27,13 @@ export function calculateCardDataPies(
                 lapses_burden[card.lapses] = (lapses_burden[card.lapses] ?? 0) + burden
                 const old_lapses_avg_burden = repetitions_avg_burden[card.reps] ?? 0
                 lapses_avg_burden[card.reps] =
-                    old_lapses_avg_burden + (old_lapses_avg_burden - burden) / lapses[card.reps]
+                    old_lapses_avg_burden + (burden - old_lapses_avg_burden) / lapses[card.reps]
 
                 repetitions_burden[card.reps] = (repetitions_burden[card.reps] ?? 0) + burden
                 const old_repetitions_avg_burden = repetitions_avg_burden[card.reps] ?? 0
                 repetitions_avg_burden[card.reps] =
                     old_repetitions_avg_burden +
-                    (old_repetitions_avg_burden - burden) / repetitions[card.reps]
+                    (burden - old_repetitions_avg_burden) / repetitions[card.reps]
 
                 const stability = JSON.parse(card.data).s
                 if (stability && card.ivl > 0 && card.type == 2 && card.queue > 0) {

--- a/src/ts/IntervalBar.svelte
+++ b/src/ts/IntervalBar.svelte
@@ -12,6 +12,8 @@
     export let binSize = 1
     export let offset = 0
 
+    export let average = false
+
     let interval_array: number[] = []
     $: {
         interval_array = []
@@ -37,4 +39,4 @@
     }
 </script>
 
-<BarScrollable data={bar_data} bind:binSize bind:offset left_aligned></BarScrollable>
+<BarScrollable data={bar_data} bind:binSize bind:offset left_aligned {average}></BarScrollable>

--- a/src/ts/IntervalGraph.svelte
+++ b/src/ts/IntervalGraph.svelte
@@ -71,7 +71,7 @@
 </div>
 {#if intervals}
     {#if $graph_mode == "Pie"}
-        <IntervalPie {intervals} {pieInfo} bind:last bind:steps></IntervalPie>
+        <IntervalPie {intervals} {pieInfo} bind:last bind:steps {average}></IntervalPie>
     {:else}
         <IntervalBar {intervals} {pieInfo} bind:binSize={last} bind:offset={steps} {average}
         ></IntervalBar>

--- a/src/ts/IntervalGraph.svelte
+++ b/src/ts/IntervalGraph.svelte
@@ -18,7 +18,7 @@
     let pieSteps = steps
     let pieLast = last
 
-    let barScroll = zero_inclusive_option ? 1 : 0
+    let barScroll = zero_inclusive_option ? 0 : 1
     let barSize = 1
 
     $: {

--- a/src/ts/IntervalGraph.svelte
+++ b/src/ts/IntervalGraph.svelte
@@ -11,6 +11,7 @@
     export let zero_inclusive_option = false
     export let intervals: Record<number, number> | null
     export let pieInfo: IntervalPieInfo = {}
+    export let average = false
 
     export let steps = 7 // For bar, scroll
     export let last = 21 // for bar, bar_size
@@ -72,7 +73,8 @@
     {#if $graph_mode == "Pie"}
         <IntervalPie {intervals} {pieInfo} bind:last bind:steps></IntervalPie>
     {:else}
-        <IntervalBar {intervals} {pieInfo} bind:binSize={last} bind:offset={steps}></IntervalBar>
+        <IntervalBar {intervals} {pieInfo} bind:binSize={last} bind:offset={steps} {average}
+        ></IntervalBar>
     {/if}
 {:else}
     <NoGraph></NoGraph>

--- a/src/ts/IntervalPie.svelte
+++ b/src/ts/IntervalPie.svelte
@@ -13,6 +13,8 @@
 
     export let pieInfo: IntervalPieInfo = {}
 
+    export let average = false
+
     $: ({
         legend_left = i18n("intervals"),
         legend_right = i18n("cards"),
@@ -70,6 +72,9 @@
             const filler_pie_slice = Object.entries(intervals)
                 .filter(([i, _]) => +i >= filler_start && +i <= filler_end)
                 .reduce((n, [_, v]) => n + v, 0)
+            if (average) {
+                //FIXME : handle the average parameters
+            }
 
             pie_data.push(
                 PieDatumFactory(filler_start, filler_end, filler_pie_slice, fillerColour ?? "gold")
@@ -80,6 +85,9 @@
         const infinite_pie_slice = Object.entries(intervals)
             .filter(([i, _]) => +i >= infinite_pie_start)
             .reduce((n, [_, v]) => n + v, 0)
+        if (average) {
+            //FIXME : handle the average parameters
+        }
 
         pie_data.push(
             PieDatumFactory(infinite_pie_start, i18n("infinity"), infinite_pie_slice, "grey")


### PR DESCRIPTION
Work in Progress

- [ ] The Pies doesn't handle the "average" which leads to false result (it will sum the average load instead of averaging them together), but in Bar mode it's OK. Can't find a nice way to add it in the existing code. ... if you have any idea @Luc-Mcgrady , feel free to suggest :)


- [ ] I might still add another graph "%-knowledge/%-load" to find if there is a good threshold to suspend cards.
![image](https://github.com/user-attachments/assets/7927060f-0f78-432c-9cf8-6801cbca8872)
For example here removing 3.5% of the card would lead to a 9.71% reduction of workload
The Average Load/Card is doing the ratio between absolute Card/Load, but it would be interesting to do the ratio between the %age I think. Maybe I could change the "Ratio" of Average Load, to instead of doing the Ratio of each Average load compared to the "sum of all averaged sum", to do the Average(% Load Gain / % Card Gain), but I feel another graph might be a bit better.