### PR TITLE
Fix/Ignore rollover for hourly breakdown 

### DIFF
--- a/src/ts/RevlogGraphs.svelte
+++ b/src/ts/RevlogGraphs.svelte
@@ -22,6 +22,7 @@
         calculateRevlogStats,
         day_ms,
         easeBarChart,
+        no_rollover_today,
         today,
         type RevlogBuckets,
     } from "./revlogGraphs"
@@ -184,8 +185,8 @@
     let range = 7
     let filtered = false
 
-    $: hours_begin = today + realScroll - range + 1
-    $: hours_end = today + realScroll + 1
+    $: hours_begin = no_rollover_today + realScroll - range + 1
+    $: hours_end = no_rollover_today + realScroll + 2
     $: day_range = filtered
         ? day_filtered_review_hours.slice(hours_begin, hours_end)
         : day_review_hours.slice(hours_begin, hours_end)

--- a/src/ts/revlogGraphs.ts
+++ b/src/ts/revlogGraphs.ts
@@ -15,6 +15,7 @@ export function dayFromMs(ms: number) {
 }
 
 export const today = dayFromMs(Date.now())
+export const no_rollover_today = Math.floor(Date.now() / day_ms)
 
 interface SiblingReview {
     cid: number
@@ -109,6 +110,7 @@ export function calculateRevlogStats(
 
     for (const revlog of revlogData) {
         const day = dayFromMs(revlog.id)
+        const no_rollover_day = Math.floor(revlog.id / day_ms)
         const hour = Math.floor(((revlog.id - timezone_offset_ms) % day_ms) / (60 * 60 * 1000))
         const ease = revlog.ease - 1
         const second = Math.round(revlog.time / 1000)
@@ -119,11 +121,13 @@ export function calculateRevlogStats(
         // Check for reschedules
         if (revlog.time != 0) {
             if (revlog.type < 3) {
-                day_review_hours[day] ??= Array(24).fill(0)
-                day_review_hours[day][hour] = day_review_hours[day][hour] + 1
+                day_review_hours[no_rollover_day] ??= Array(24).fill(0)
+                day_review_hours[no_rollover_day][hour] =
+                    day_review_hours[no_rollover_day][hour] + 1
             }
-            day_filtered_review_hours[day] ??= Array(24).fill(0)
-            day_filtered_review_hours[day][hour] = day_filtered_review_hours[day][hour] + 1
+            day_filtered_review_hours[no_rollover_day] ??= Array(24).fill(0)
+            day_filtered_review_hours[no_rollover_day][hour] =
+                day_filtered_review_hours[no_rollover_day][hour] + 1
 
             day_review_count[day] = (day_review_count[day] ?? -1) + 1
             incrementEase(fatigue_ease.all, day_review_count[day], ease)


### PR DESCRIPTION
closes #48 

Here are the graphs after I did 1 review at 1am (My rollover is 4am).

![image](https://github.com/user-attachments/assets/40c0ac2d-df53-436b-9cd6-de0340d53fc7)
![image](https://github.com/user-attachments/assets/d72b8b21-23fd-4888-a82f-dabc867029b1)
