### PR TITLE
Add Time Distribution by Retrievability and Stability buckets

### DIFF
--- a/locale/en_GB.ftl
+++ b/locale/en_GB.ftl
@@ -132,6 +132,7 @@ reset = Reset
 interval-of = Interval of {$value}
 difficulty-of = Difficulty of {$value}
 stability-of = Stability of {$value}
+retrievability-of = Retrievability of {$value}
 factor-of = Increase of {$value}%
 x-seconds = {$value} Seconds
 # e.g
@@ -231,6 +232,12 @@ suspended-cards-warning =
 time-totals = Time Totals
 time-totals-help =
     The quantity of time that has been spent on cards which have taken the given amount of time to answer over every review
+time-distribution-by-retrievability = Time Distribution by Retrievability
+time-distribution-by-retrievability-help =
+    The average or median answer time (seconds) grouped by predicted retrievability bucket before each review.
+time-distribution-by-stability = Time Distribution by Stability
+time-distribution-by-stability-help =
+    The average or median answer time (seconds) grouped by predicted stability bucket (days) before each review.
 
 introduced = Introduced
 re-introduced = Re-Introduced

--- a/locale/en_GB.ftl
+++ b/locale/en_GB.ftl
@@ -155,6 +155,20 @@ average-second-per-day = {$value} {$value ->
         [one] day
         *[many] {$n} days
     }
+average-second-per-retrievability-percent = {$value} {$value ->
+        [one] second
+        *[many] seconds
+    } on average per {$n ->
+        [one] 1% retrievability bucket
+        *[many] {$n}% retrievability buckets
+    }
+average-second-per-stability-day = {$value} {$value ->
+        [one] second
+        *[many] seconds
+    } on average per {$n ->
+        [one] 1-day stability bucket
+        *[many] {$n}-day stability buckets
+    }
 
 sxr-heatmap = SxR Heatmap
 sxr-heatmap-help =

--- a/locale/pt_BR.ftl
+++ b/locale/pt_BR.ftl
@@ -118,6 +118,7 @@ reset = Redefinir
 interval-of = Intervalo de {$value}
 difficulty-of = Dificuldade de {$value}
 stability-of = Estabilidade de {$value}
+retrievability-of = Recuperabilidade de {$value}
 x-seconds = {$value} Segundos
 # e.g
 # x = Interval
@@ -219,6 +220,12 @@ suspended-cards-warning =
 time-totals = Totais de Tempo
 time-totals-help =
     A quantidade de tempo que foi gasta em cartões que levaram um determinado tempo para serem respondidos em todas as revisões.
+time-distribution-by-retrievability = Distribuição de Tempo por Recuperabilidade
+time-distribution-by-retrievability-help =
+    O tempo médio ou mediano de resposta (segundos), agrupado por faixa de recuperabilidade prevista antes de cada revisão.
+time-distribution-by-stability = Distribuição de Tempo por Estabilidade
+time-distribution-by-stability-help =
+    O tempo médio ou mediano de resposta (segundos), agrupado por faixa de estabilidade prevista (dias) antes de cada revisão.
 
 introduced = Introduzidos
 re-introduced = Reintroduzidos

--- a/locale/zh_CN.ftl
+++ b/locale/zh_CN.ftl
@@ -119,6 +119,7 @@ reset = 重置
 interval-of = {$value}天间隔
 difficulty-of = {$value}的难度
 stability-of = {$value}的稳定期
+retrievability-of = {$value}的可提取性
 factor-of = Increase of {$value}%
 x-seconds = {$value}秒
 # e.g 
@@ -229,6 +230,12 @@ suspended-cards-warning =
 time-totals = 时间总计
 time-totals-help = 
     各耗时区间的总时间累积。
+time-distribution-by-retrievability = 按可提取性划分的耗时分布
+time-distribution-by-retrievability-help =
+    按每次复习前预测可提取性分箱，显示答题耗时（秒）的均值或中位数。
+time-distribution-by-stability = 按稳定期划分的耗时分布
+time-distribution-by-stability-help =
+    按每次复习前预测稳定期（天）分箱，显示答题耗时（秒）的均值或中位数。
 
 introduced = 新学习
 re-introduced = 重新学习

--- a/src/ts/MemorisedBar.ts
+++ b/src/ts/MemorisedBar.ts
@@ -186,6 +186,33 @@ function stability_weight(s: number): number {
 const R_BIN_POWER = 1.4
 const LOG_R_BIN_POWER = Math.log(R_BIN_POWER)
 
+function median(values: number[]) {
+    if (!values.length) {
+        return 0
+    }
+    const sorted = [...values].sort((a, b) => a - b)
+    const middle = Math.floor(sorted.length / 2)
+    if (sorted.length % 2 === 1) {
+        return sorted[middle]
+    }
+    return (sorted[middle - 1] + sorted[middle]) / 2
+}
+
+function bucketTimeStats(bucketedSamples: number[][]) {
+    const meanByBucket: number[] = []
+    const medianByBucket: number[] = []
+
+    bucketedSamples.forEach((samples, bucket) => {
+        if (!samples?.length) {
+            return
+        }
+        meanByBucket[bucket] = _.sum(samples) / samples.length
+        medianByBucket[bucket] = median(samples)
+    })
+
+    return { meanByBucket, medianByBucket }
+}
+
 export function getMemorisedDays(
     revlogs: Revlog[],
     cards: CardData[],
@@ -291,6 +318,8 @@ export function getMemorisedDays(
     let last_day = dayFromMs(revlogs[0].id)
     const uniqueCids = new Set(revlogs.map((r) => r.cid))
     let probabilities: Record<number, number[]> = {}
+    let time_by_retrievability_samples: number[][] = []
+    let time_by_stability_samples: number[][] = []
     for (const cid of uniqueCids) probabilities[cid] = [1]
 
     // let log: any[] = []
@@ -357,6 +386,16 @@ export function getMemorisedDays(
             }
 
             const p = fsrs.forgetting_curve(elapsed, card.stability)
+            if (revlog.time > 0 && card.stability > 0) {
+                const seconds = revlog.time / 1000
+                const retrievabilityBucket = Math.max(0, Math.min(99, Math.floor(p * 100)))
+                const stabilityBucket = Math.max(0, Math.round(card.stability))
+
+                time_by_retrievability_samples[retrievabilityBucket] ??= []
+                time_by_retrievability_samples[retrievabilityBucket].push(seconds)
+                time_by_stability_samples[stabilityBucket] ??= []
+                time_by_stability_samples[stabilityBucket].push(seconds)
+            }
             const y = grade > 1 ? 1 : 0
 
             let card_type: LossBin[]
@@ -479,6 +518,8 @@ export function getMemorisedDays(
     const leech_probabilities = _.mapValues(probabilities, (p) =>
         p.length > leech_min_reviews ? _.sum(p) : 1
     )
+    const retrievabilityTimeStats = bucketTimeStats(time_by_retrievability_samples)
+    const stabilityTimeStats = bucketTimeStats(time_by_stability_samples)
     console.timeEnd("Calculating memorised days")
     return {
         retrievabilityDays,
@@ -493,5 +534,9 @@ export function getMemorisedDays(
         leech_probabilities,
         difficulty_days: difficulty_day_bins,
         calibration,
+        time_by_retrievability_mean: retrievabilityTimeStats.meanByBucket,
+        time_by_retrievability_median: retrievabilityTimeStats.medianByBucket,
+        time_by_stability_mean: stabilityTimeStats.meanByBucket,
+        time_by_stability_median: stabilityTimeStats.medianByBucket,
     }
 }

--- a/src/ts/categories/TimeDistributionCategory.svelte
+++ b/src/ts/categories/TimeDistributionCategory.svelte
@@ -4,7 +4,7 @@
     import RevlogGraphContainer from "../RevlogGraphContainer.svelte"
     import IntervalGraph from "../IntervalGraph.svelte"
     import GraphCategory from "../GraphCategory.svelte"
-    import { i18n } from "../i18n"
+    import { i18n, i18n_pattern } from "../i18n"
     import { pieLast, pieSteps, revlogStats } from "../stores"
 
     enum AverageType {
@@ -113,7 +113,10 @@
         <BarScrollable
             slot="graph"
             data={retrievabilityTimeBar}
+            average
             bind:binSize={retrievabilityBinSize}
+            trend
+            trend_info={{ pattern: i18n_pattern("average-second-per-day") }}
         />
         <div class="toggle">
             <label>
@@ -132,8 +135,11 @@
         <BarScrollable
             slot="graph"
             data={stabilityTimeBar}
+            average
             left_aligned
             bind:binSize={stabilityBinSize}
+            trend
+            trend_info={{ pattern: i18n_pattern("average-second-per-day") }}
         />
         <div class="toggle">
             <label>

--- a/src/ts/categories/TimeDistributionCategory.svelte
+++ b/src/ts/categories/TimeDistributionCategory.svelte
@@ -1,9 +1,67 @@
 <script lang="ts">
+    import type { BarChart } from "../bar"
+    import BarScrollable from "../BarScrollable.svelte"
     import RevlogGraphContainer from "../RevlogGraphContainer.svelte"
     import IntervalGraph from "../IntervalGraph.svelte"
     import GraphCategory from "../GraphCategory.svelte"
     import { i18n } from "../i18n"
     import { pieLast, pieSteps, revlogStats } from "../stores"
+
+    enum AverageType {
+        MEAN,
+        MEDIAN,
+    }
+
+    let averageType = AverageType.MEAN
+    let retrievabilityBinSize = 2
+    let stabilityBinSize = 2
+
+    function retrievabilityBucketLabeler(label: string, width = 1) {
+        const raw = Number(label)
+        const start = raw < 0 ? 99 + raw : raw
+        const end = Math.min(100, start + width)
+        return i18n("retrievability-of", { value: `${start}-${end}%` })
+    }
+
+    function stabilityBucketLabeler(label: string, width = 1) {
+        const start = Number(label)
+        const end = width > 1 ? `${start}-${start + width - 1}` : label
+        return i18n("stability-of", { value: end })
+    }
+
+    $: retrievabilitySeries =
+        averageType === AverageType.MEAN
+            ? ($revlogStats?.time_by_retrievability_mean ?? [])
+            : ($revlogStats?.time_by_retrievability_median ?? [])
+
+    let retrievabilityTimeBar: BarChart
+    $: retrievabilityTimeBar = {
+        row_colours: ["#fcba03"],
+        row_labels: [i18n("seconds")],
+        data: Array.from(retrievabilitySeries).map((value, bucket) => ({
+            values: [value ?? 0],
+            label: bucket.toString(),
+        })),
+        tick_spacing: 10,
+        columnLabeler: retrievabilityBucketLabeler,
+    }
+
+    $: stabilitySeries =
+        averageType === AverageType.MEAN
+            ? ($revlogStats?.time_by_stability_mean ?? [])
+            : ($revlogStats?.time_by_stability_median ?? [])
+
+    let stabilityTimeBar: BarChart
+    $: stabilityTimeBar = {
+        row_colours: ["#fcba03"],
+        row_labels: [i18n("seconds")],
+        data: Array.from(stabilitySeries).map((value, bucket) => ({
+            values: [value ?? 0],
+            label: bucket.toString(),
+        })),
+        tick_spacing: 10,
+        columnLabeler: stabilityBucketLabeler,
+    }
 </script>
 
 <GraphCategory hidden_title={i18n("time-distribution")} config_name="time">
@@ -50,4 +108,51 @@
             {i18n("time-totals-help")}
         </p>
     </RevlogGraphContainer>
+    <RevlogGraphContainer>
+        <h1 slot="title">{i18n("time-distribution-by-retrievability")}</h1>
+        <BarScrollable
+            slot="graph"
+            data={retrievabilityTimeBar}
+            bind:binSize={retrievabilityBinSize}
+        />
+        <div class="toggle">
+            <label>
+                <input type="radio" value={AverageType.MEAN} bind:group={averageType} />
+                {i18n("mean")}
+            </label>
+            <label>
+                <input type="radio" value={AverageType.MEDIAN} bind:group={averageType} />
+                {i18n("median")}
+            </label>
+        </div>
+        <p>{i18n("time-distribution-by-retrievability-help")}</p>
+    </RevlogGraphContainer>
+    <RevlogGraphContainer>
+        <h1 slot="title">{i18n("time-distribution-by-stability")}</h1>
+        <BarScrollable
+            slot="graph"
+            data={stabilityTimeBar}
+            left_aligned
+            bind:binSize={stabilityBinSize}
+        />
+        <div class="toggle">
+            <label>
+                <input type="radio" value={AverageType.MEAN} bind:group={averageType} />
+                {i18n("mean")}
+            </label>
+            <label>
+                <input type="radio" value={AverageType.MEDIAN} bind:group={averageType} />
+                {i18n("median")}
+            </label>
+        </div>
+        <p>{i18n("time-distribution-by-stability-help")}</p>
+    </RevlogGraphContainer>
 </GraphCategory>
+
+<style>
+    div.toggle {
+        display: flex;
+        gap: 1em;
+        margin-top: 0.5em;
+    }
+</style>

--- a/src/ts/categories/TimeDistributionCategory.svelte
+++ b/src/ts/categories/TimeDistributionCategory.svelte
@@ -5,7 +5,7 @@
     import IntervalGraph from "../IntervalGraph.svelte"
     import GraphCategory from "../GraphCategory.svelte"
     import { i18n, i18n_pattern } from "../i18n"
-    import { pieLast, pieSteps, revlogStats } from "../stores"
+    import { memorised_stats, pieLast, pieSteps, revlogStats } from "../stores"
 
     enum AverageType {
         MEAN,
@@ -31,8 +31,8 @@
 
     $: retrievabilitySeries =
         averageType === AverageType.MEAN
-            ? ($revlogStats?.time_by_retrievability_mean ?? [])
-            : ($revlogStats?.time_by_retrievability_median ?? [])
+            ? ($memorised_stats?.time_by_retrievability_mean ?? [])
+            : ($memorised_stats?.time_by_retrievability_median ?? [])
 
     let retrievabilityTimeBar: BarChart
     $: retrievabilityTimeBar = {
@@ -48,8 +48,8 @@
 
     $: stabilitySeries =
         averageType === AverageType.MEAN
-            ? ($revlogStats?.time_by_stability_mean ?? [])
-            : ($revlogStats?.time_by_stability_median ?? [])
+            ? ($memorised_stats?.time_by_stability_mean ?? [])
+            : ($memorised_stats?.time_by_stability_median ?? [])
 
     let stabilityTimeBar: BarChart
     $: stabilityTimeBar = {

--- a/src/ts/categories/TimeDistributionCategory.svelte
+++ b/src/ts/categories/TimeDistributionCategory.svelte
@@ -116,7 +116,7 @@
             average
             bind:binSize={retrievabilityBinSize}
             trend
-            trend_info={{ pattern: i18n_pattern("average-second-per-day") }}
+            trend_info={{ pattern: i18n_pattern("average-second-per-retrievability-percent") }}
         />
         <div class="toggle">
             <label>
@@ -139,7 +139,7 @@
             left_aligned
             bind:binSize={stabilityBinSize}
             trend
-            trend_info={{ pattern: i18n_pattern("average-second-per-day") }}
+            trend_info={{ pattern: i18n_pattern("average-second-per-stability-day") }}
         />
         <div class="toggle">
             <label>

--- a/src/ts/revlogGraphs.ts
+++ b/src/ts/revlogGraphs.ts
@@ -30,10 +30,7 @@ export const no_rollover_today = Math.floor(Date.now() / day_ms)
 
 let deckFsrs: Record<number, FSRS> = {}
 
-function getFsrs(config: {
-    id: number
-    fsrsParams6: number[]
-}) {
+function getFsrs(config: { id: number; fsrsParams6: number[] }) {
     const id = config.id
     if (!deckFsrs[id]) {
         deckFsrs[id] = Fsrs(

--- a/src/ts/revlogGraphs.ts
+++ b/src/ts/revlogGraphs.ts
@@ -1,10 +1,19 @@
 import _ from "lodash"
-import { FSRS5_DEFAULT_DECAY } from "ts-fsrs"
+import {
+    type Card,
+    checkParameters,
+    createEmptyCard,
+    type FSRS,
+    fsrs as Fsrs,
+    FSRS5_DEFAULT_DECAY,
+    type FSRSState,
+    generatorParameters,
+} from "ts-fsrs"
 import type { BarChart, BarDatum } from "./bar"
 import { totalCalc } from "./barHelpers"
 import { averageDecay, type ForgettingSample } from "./forgettingCurveData"
 import { i18n } from "./i18n"
-import { getCardDecay, type CardData, type Revlog } from "./search"
+import { type CardData, getCardDecay, type Revlog } from "./search"
 
 const rollover = SSEother.rollover ?? 0
 export const rollover_ms = rollover * 60 * 60 * 1000
@@ -18,6 +27,52 @@ export function dayFromMs(ms: number) {
 
 export const today = dayFromMs(Date.now())
 export const no_rollover_today = Math.floor(Date.now() / day_ms)
+
+let deckFsrs: Record<number, FSRS> = {}
+
+function getFsrs(config: {
+    id: number
+    fsrsParams6: number[]
+}) {
+    const id = config.id
+    if (!deckFsrs[id]) {
+        deckFsrs[id] = Fsrs(
+            generatorParameters({
+                w: checkParameters(config.fsrsParams6),
+                enable_fuzz: false,
+                enable_short_term: true,
+            })
+        )
+    }
+    return deckFsrs[id]
+}
+
+function median(values: number[]) {
+    if (!values.length) {
+        return 0
+    }
+    const sorted = [...values].sort((a, b) => a - b)
+    const middle = Math.floor(sorted.length / 2)
+    if (sorted.length % 2 === 1) {
+        return sorted[middle]
+    }
+    return (sorted[middle - 1] + sorted[middle]) / 2
+}
+
+function bucketTimeStats(bucketedSamples: number[][]) {
+    const meanByBucket: number[] = []
+    const medianByBucket: number[] = []
+
+    bucketedSamples.forEach((samples, bucket) => {
+        if (!samples?.length) {
+            return
+        }
+        meanByBucket[bucket] = _.sum(samples) / samples.length
+        medianByBucket[bucket] = median(samples)
+    })
+
+    return { meanByBucket, medianByBucket }
+}
 
 interface SiblingReview {
     cid: number
@@ -59,6 +114,8 @@ export function calculateRevlogStats(
 ) {
     console.time("revlog stats")
     let id_card_data = IDify(cardData)
+    let fsrsCards: Record<number, Card> = {}
+    deckFsrs = {}
 
     function emptyArray<T>(init: T): T[] {
         const empty_array: T[] = []
@@ -116,6 +173,20 @@ export function calculateRevlogStats(
     let short_term_recorded_cards: Set<number> = new Set()
     let forgetting_samples: ForgettingSample[] = []
     let forgetting_samples_short: ForgettingSample[] = []
+    let time_by_retrievability_samples: number[][] = []
+    let time_by_stability_samples: number[][] = []
+
+    function card_config(cid: number) {
+        const card = id_card_data[cid]
+        if (!card) {
+            return undefined
+        }
+        const configId = SSEother.deck_config_ids?.[card.odid || card.did]
+        if (configId === undefined) {
+            return undefined
+        }
+        return SSEother.deck_configs?.[configId]
+    }
 
     function incrementEase(ease_array: number[][], day: number, ease: number, amount = 1) {
         // Doesn't check for negative ease (manual reschedule)
@@ -211,6 +282,55 @@ export function calculateRevlogStats(
         const hasRating = revlog.ease > 0
         const isResetEntry = !hasRating && revlog.factor === 0
         const isCrammingEntry = hasRating && revlog.type === 3 && revlog.factor === 0
+        const config = card_config(revlog.cid)
+
+        if (config) {
+            const fsrs = getFsrs(config)
+            const now = new Date(revlog.id)
+            const hasPreviousReview = !!fsrsCards[revlog.cid]
+            let fsrsCard = fsrsCards[revlog.cid] ?? createEmptyCard(new Date(revlog.cid))
+
+            if (revlog.factor == 0 && revlog.type == 4 && hasPreviousReview) {
+                fsrsCard = fsrs.forget(fsrsCard, now).card
+                fsrsCards[revlog.cid] = fsrsCard
+            }
+
+            if (hasRating && !isCrammingEntry) {
+                let memoryState: FSRSState | null = null
+                let elapsed = 0
+
+                if (fsrsCard.last_review) {
+                    memoryState = fsrsCard.stability
+                        ? {
+                              difficulty: fsrsCard.difficulty,
+                              stability: fsrsCard.stability,
+                          }
+                        : null
+                    elapsed = dayFromMs(now.getTime()) - dayFromMs(fsrsCard.last_review.getTime())
+
+                    if (revlog.time > 0 && fsrsCard.stability > 0) {
+                        const seconds = revlog.time / 1000
+                        const retrievability = fsrs.forgetting_curve(elapsed, fsrsCard.stability)
+                        const retrievabilityBucket = Math.max(
+                            0,
+                            Math.min(99, Math.floor(retrievability * 100))
+                        )
+                        const stabilityBucket = Math.max(0, Math.round(fsrsCard.stability))
+
+                        time_by_retrievability_samples[retrievabilityBucket] ??= []
+                        time_by_retrievability_samples[retrievabilityBucket].push(seconds)
+                        time_by_stability_samples[stabilityBucket] ??= []
+                        time_by_stability_samples[stabilityBucket].push(seconds)
+                    }
+                }
+
+                const newState = fsrs.next_state(memoryState, elapsed, revlog.ease)
+                fsrsCard.last_review = now
+                fsrsCard.stability = newState.stability
+                fsrsCard.difficulty = newState.difficulty
+                fsrsCards[revlog.cid] = fsrsCard
+            }
+        }
 
         if (isResetEntry) {
             forgetting_samples = forgetting_samples.filter((sample) => sample.cid !== revlog.cid)
@@ -339,6 +459,8 @@ export function calculateRevlogStats(
         .map((card) => getCardDecay(card))
     const forgetting_curve_decay =
         decayValues.length > 0 ? averageDecay(decayValues) : FSRS5_DEFAULT_DECAY
+    const retrievabilityTimeStats = bucketTimeStats(time_by_retrievability_samples)
+    const stabilityTimeStats = bucketTimeStats(time_by_stability_samples)
 
     console.timeEnd("revlog stats")
 
@@ -366,6 +488,10 @@ export function calculateRevlogStats(
         forgetting_samples,
         forgetting_samples_short,
         forgetting_curve_decay,
+        time_by_retrievability_mean: retrievabilityTimeStats.meanByBucket,
+        time_by_retrievability_median: retrievabilityTimeStats.medianByBucket,
+        time_by_stability_mean: stabilityTimeStats.meanByBucket,
+        time_by_stability_median: stabilityTimeStats.medianByBucket,
     }
 }
 

--- a/src/ts/revlogGraphs.ts
+++ b/src/ts/revlogGraphs.ts
@@ -1,15 +1,5 @@
 import _ from "lodash"
-import {
-    type Card,
-    checkParameters,
-    createEmptyCard,
-    default_w,
-    type FSRS,
-    fsrs as Fsrs,
-    FSRS5_DEFAULT_DECAY,
-    type FSRSState,
-    generatorParameters,
-} from "ts-fsrs"
+import { FSRS5_DEFAULT_DECAY } from "ts-fsrs"
 import type { BarChart, BarDatum } from "./bar"
 import { totalCalc } from "./barHelpers"
 import { averageDecay, type ForgettingSample } from "./forgettingCurveData"
@@ -28,63 +18,6 @@ export function dayFromMs(ms: number) {
 
 export const today = dayFromMs(Date.now())
 export const no_rollover_today = Math.floor(Date.now() / day_ms)
-
-let deckFsrs: Record<number, FSRS> = {}
-
-function getFsrs(config: {
-    id: number
-    fsrsParams6?: number[]
-    fsrsParams5?: number[]
-    fsrsParams4?: number[]
-    fsrsWeights?: number[]
-}) {
-    const id = config.id
-    if (!deckFsrs[id]) {
-        const configParams = [
-            config.fsrsParams6,
-            config.fsrsParams5,
-            config.fsrsParams4,
-            config.fsrsWeights,
-        ]
-        const params = configParams.find((arr) => Array.isArray(arr) && arr.length > 0) ?? default_w
-
-        deckFsrs[id] = Fsrs(
-            generatorParameters({
-                w: checkParameters(params),
-                enable_fuzz: false,
-                enable_short_term: true,
-            })
-        )
-    }
-    return deckFsrs[id]
-}
-
-function median(values: number[]) {
-    if (!values.length) {
-        return 0
-    }
-    const sorted = [...values].sort((a, b) => a - b)
-    const middle = Math.floor(sorted.length / 2)
-    if (sorted.length % 2 === 1) {
-        return sorted[middle]
-    }
-    return (sorted[middle - 1] + sorted[middle]) / 2
-}
-
-function bucketTimeStats(bucketedSamples: number[][]) {
-    const meanByBucket: number[] = []
-    const medianByBucket: number[] = []
-
-    bucketedSamples.forEach((samples, bucket) => {
-        if (!samples?.length) {
-            return
-        }
-        meanByBucket[bucket] = _.sum(samples) / samples.length
-        medianByBucket[bucket] = median(samples)
-    })
-
-    return { meanByBucket, medianByBucket }
-}
 
 interface SiblingReview {
     cid: number
@@ -126,8 +59,6 @@ export function calculateRevlogStats(
 ) {
     console.time("revlog stats")
     let id_card_data = IDify(cardData)
-    let fsrsCards: Record<number, Card> = {}
-    deckFsrs = {}
 
     function emptyArray<T>(init: T): T[] {
         const empty_array: T[] = []
@@ -185,20 +116,6 @@ export function calculateRevlogStats(
     let short_term_recorded_cards: Set<number> = new Set()
     let forgetting_samples: ForgettingSample[] = []
     let forgetting_samples_short: ForgettingSample[] = []
-    let time_by_retrievability_samples: number[][] = []
-    let time_by_stability_samples: number[][] = []
-
-    function card_config(cid: number) {
-        const card = id_card_data[cid]
-        if (!card) {
-            return undefined
-        }
-        const configId = SSEother.deck_config_ids?.[card.odid || card.did]
-        if (configId === undefined) {
-            return undefined
-        }
-        return SSEother.deck_configs?.[configId]
-    }
 
     function incrementEase(ease_array: number[][], day: number, ease: number, amount = 1) {
         // Doesn't check for negative ease (manual reschedule)
@@ -294,55 +211,6 @@ export function calculateRevlogStats(
         const hasRating = revlog.ease > 0
         const isResetEntry = !hasRating && revlog.factor === 0
         const isCrammingEntry = hasRating && revlog.type === 3 && revlog.factor === 0
-        const config = card_config(revlog.cid)
-
-        if (config) {
-            const fsrs = getFsrs(config)
-            const now = new Date(revlog.id)
-            const hasPreviousReview = !!fsrsCards[revlog.cid]
-            let fsrsCard = fsrsCards[revlog.cid] ?? createEmptyCard(new Date(revlog.cid))
-
-            if (revlog.factor == 0 && revlog.type == 4 && hasPreviousReview) {
-                fsrsCard = fsrs.forget(fsrsCard, now).card
-                fsrsCards[revlog.cid] = fsrsCard
-            }
-
-            if (hasRating && !isCrammingEntry) {
-                let memoryState: FSRSState | null = null
-                let elapsed = 0
-
-                if (fsrsCard.last_review) {
-                    memoryState = fsrsCard.stability
-                        ? {
-                              difficulty: fsrsCard.difficulty,
-                              stability: fsrsCard.stability,
-                          }
-                        : null
-                    elapsed = dayFromMs(now.getTime()) - dayFromMs(fsrsCard.last_review.getTime())
-
-                    if (revlog.time > 0 && fsrsCard.stability > 0) {
-                        const seconds = revlog.time / 1000
-                        const retrievability = fsrs.forgetting_curve(elapsed, fsrsCard.stability)
-                        const retrievabilityBucket = Math.max(
-                            0,
-                            Math.min(99, Math.floor(retrievability * 100))
-                        )
-                        const stabilityBucket = Math.max(0, Math.round(fsrsCard.stability))
-
-                        time_by_retrievability_samples[retrievabilityBucket] ??= []
-                        time_by_retrievability_samples[retrievabilityBucket].push(seconds)
-                        time_by_stability_samples[stabilityBucket] ??= []
-                        time_by_stability_samples[stabilityBucket].push(seconds)
-                    }
-                }
-
-                const newState = fsrs.next_state(memoryState, elapsed, revlog.ease)
-                fsrsCard.last_review = now
-                fsrsCard.stability = newState.stability
-                fsrsCard.difficulty = newState.difficulty
-                fsrsCards[revlog.cid] = fsrsCard
-            }
-        }
 
         if (isResetEntry) {
             forgetting_samples = forgetting_samples.filter((sample) => sample.cid !== revlog.cid)
@@ -471,8 +339,6 @@ export function calculateRevlogStats(
         .map((card) => getCardDecay(card))
     const forgetting_curve_decay =
         decayValues.length > 0 ? averageDecay(decayValues) : FSRS5_DEFAULT_DECAY
-    const retrievabilityTimeStats = bucketTimeStats(time_by_retrievability_samples)
-    const stabilityTimeStats = bucketTimeStats(time_by_stability_samples)
 
     console.timeEnd("revlog stats")
 
@@ -500,10 +366,6 @@ export function calculateRevlogStats(
         forgetting_samples,
         forgetting_samples_short,
         forgetting_curve_decay,
-        time_by_retrievability_mean: retrievabilityTimeStats.meanByBucket,
-        time_by_retrievability_median: retrievabilityTimeStats.medianByBucket,
-        time_by_stability_mean: stabilityTimeStats.meanByBucket,
-        time_by_stability_median: stabilityTimeStats.medianByBucket,
     }
 }
 

--- a/src/ts/revlogGraphs.ts
+++ b/src/ts/revlogGraphs.ts
@@ -3,6 +3,7 @@ import {
     type Card,
     checkParameters,
     createEmptyCard,
+    default_w,
     type FSRS,
     fsrs as Fsrs,
     FSRS5_DEFAULT_DECAY,
@@ -30,12 +31,26 @@ export const no_rollover_today = Math.floor(Date.now() / day_ms)
 
 let deckFsrs: Record<number, FSRS> = {}
 
-function getFsrs(config: { id: number; fsrsParams6: number[] }) {
+function getFsrs(config: {
+    id: number
+    fsrsParams6?: number[]
+    fsrsParams5?: number[]
+    fsrsParams4?: number[]
+    fsrsWeights?: number[]
+}) {
     const id = config.id
     if (!deckFsrs[id]) {
+        const configParams = [
+            config.fsrsParams6,
+            config.fsrsParams5,
+            config.fsrsParams4,
+            config.fsrsWeights,
+        ]
+        const params = configParams.find((arr) => Array.isArray(arr) && arr.length > 0) ?? default_w
+
         deckFsrs[id] = Fsrs(
             generatorParameters({
-                w: checkParameters(config.fsrsParams6),
+                w: checkParameters(params),
                 enable_fuzz: false,
                 enable_short_term: true,
             })

--- a/test/memorised.test.ts
+++ b/test/memorised.test.ts
@@ -1,57 +1,27 @@
-import { fsrs } from "ts-fsrs"
-import { getMemorisedDays } from "../src/ts/MemorisedBar"
-import type { DeckConfig } from "../src/ts/config"
-import { Revlog } from "../src/ts/search"
 import { RevlogBuilder } from "./revlogBuilder"
+import {getMemorisedDays} from "../src/ts/MemorisedBar"
+import type {DeckConfig} from "../src/ts/config"
+import { Revlog } from "../src/ts/search"
+import {fsrs} from "ts-fsrs"
 
 const weights = [
-    0.40255,
-    1.18385,
-    3.173,
-    15.69105,
-    7.1949,
-    0.5345,
-    1.4604,
-    0.0046,
-    1.54575,
-    0.1192,
-    1.01925,
-    1.9395,
-    0.11,
-    0.29605,
-    2.2698,
-    0.2315,
-    2.9898,
-    0.51655,
-    0.6621, // Defaults
+    0.40255, 1.18385, 3.173, 15.69105, 7.1949, 0.5345, 1.4604, 0.0046, 1.54575, 0.1192, 1.01925,
+    1.9395, 0.11, 0.29605, 2.2698, 0.2315, 2.9898, 0.51655, 0.6621, // Defaults
 ]
 const weights2 = [
-    1,
-    100,
-    100,
-    100,
-    7.1949,
-    0.5345,
-    1.4604,
-    0.0046,
-    1.54575,
-    0.1192,
-    1.01925,
-    1.9395,
-    0.11,
-    0.29605,
-    2.2698,
-    0.2315,
-    2.9898, // on initial good: 100, no intra-day
+    1, 100, 100, 100, 7.1949, 0.5345, 1.4604, 0.0046, 1.54575, 0.1192, 1.01925,
+    1.9395, 0.11, 0.29605, 2.2698, 0.2315, 2.9898 // on initial good: 100, no intra-day
 ]
 
-const mappings = { 1: 1, 2: 2 }
+const mappings = {1: 1, 2: 2}
 const configs: Record<number, Partial<DeckConfig>> = {
-    1: { id: 1, fsrsWeights: weights, fsrsParams5: weights },
-    2: { id: 2, fsrsWeights: weights2, fsrsParams5: weights2 },
+    1: {id: 1, fsrsWeights: weights, fsrsParams5: weights},
+    2: {id: 2, fsrsWeights: weights2, fsrsParams5: weights2}
 }
 
-test("Day Timings", () => {
+
+
+test("Day Timings", ()=>{
     const card = new RevlogBuilder()
 
     const revlogs = [
@@ -62,18 +32,13 @@ test("Day Timings", () => {
         card.review(20, 3),
     ] as Revlog[]
 
-    const memorised = getMemorisedDays(
-        revlogs,
-        [
-            {
-                ...card.card(),
-                did: 1,
-            } as any,
-        ],
-        configs,
-        mappings
-    ).retrievabilityDays
-
+    const memorised = getMemorisedDays(revlogs, [{
+        ...card.card(),
+        did: 1
+    } as any],
+    configs,
+    mappings).retrievabilityDays
+    
     expect(memorised.length).not.toBe(0)
     expect(memorised[0]).toBe(1)
     expect(memorised[5]).toBe(1)
@@ -82,9 +47,9 @@ test("Day Timings", () => {
 })
 
 // https://github.com/open-spaced-repetition/fsrs-rs/blob/a7aaa40498bae992e0be0a1e9a1380e4992aee60/src/inference.rs#L433-L465
-test("Stability", () => {
+test("Stability", ()=>{
     const card = new RevlogBuilder()
-    const FSRS = fsrs({ w: weights })
+    const FSRS = fsrs({w: weights})
 
     const revlogs = [
         card.review(1, 1),
@@ -93,28 +58,22 @@ test("Stability", () => {
         card.review(80, 3),
     ] as Revlog[]
 
-    const memorised = getMemorisedDays(
-        revlogs,
-        [
-            {
-                ...card.card(),
-                did: 1,
-            } as any,
-        ],
-        configs,
-        mappings
-    ).retrievabilityDays
+    const memorised = getMemorisedDays(revlogs, [{
+        ...card.card(),
+        did: 1
+    } as any],
+    configs,
+    mappings).retrievabilityDays
 
     const OFFSET = 10
 
-    expect(memorised[card.last_review + OFFSET]).toBeCloseTo(
-        FSRS.forgetting_curve(OFFSET, 31.722975)
-    )
+    expect(memorised[card.last_review + OFFSET]).toBeCloseTo(FSRS.forgetting_curve(OFFSET, 31.722975))
+
 })
 
-test("Stability On Forget", () => {
+test("Stability On Forget", ()=>{
     const card = new RevlogBuilder()
-    const FSRS = fsrs({ w: weights })
+    const FSRS = fsrs({w: weights})
 
     const revlogs = [
         card.review(1, 1),
@@ -126,44 +85,34 @@ test("Stability On Forget", () => {
         card.review(80, 3),
     ] as Revlog[]
 
-    const memorised = getMemorisedDays(
-        revlogs,
-        [
-            {
-                ...card.card(),
-                did: 1,
-            } as any,
-        ],
-        configs,
-        mappings
-    ).retrievabilityDays
+    const memorised = getMemorisedDays(revlogs, [{
+        ...card.card(),
+        did: 1
+    } as any],
+    configs,
+    mappings).retrievabilityDays
 
     const OFFSET = 10
 
-    expect(memorised[card.last_review + OFFSET]).toBeCloseTo(
-        FSRS.forgetting_curve(OFFSET, 31.722975)
-    )
+    expect(memorised[card.last_review + OFFSET]).toBeCloseTo(FSRS.forgetting_curve(OFFSET, 31.722975))
+
 })
 
-test("Leech Detection", () => {
+test("Leech Detection", () =>{
     const card = new RevlogBuilder()
+    
+    const revlogs = [
+        card.review(-100, 3),
+        card.review(100, 3),
+        card.review(100, 1)
+    ] as Revlog[]
 
-    const revlogs = [card.review(-100, 3), card.review(100, 3), card.review(100, 1)] as Revlog[]
-
-    const leech_probabilities = getMemorisedDays(
-        revlogs,
-        [
-            {
-                ...card.card(),
-                did: 2,
-            } as any,
-        ],
-        configs,
-        mappings,
-        [],
-        1,
-        0
-    ).leech_probabilities
+    const leech_probabilities = getMemorisedDays(revlogs, [{
+        ...card.card(),
+        did: 2
+    } as any],
+    configs,
+    mappings, [], 1, 0).leech_probabilities
 
     expect(leech_probabilities[card.card().id]).toBeCloseTo(0.1)
 })
@@ -180,12 +129,11 @@ test("Time distribution by retrievability and stability is generated", () => {
         card.review(3, 2, 6000),
     ].filter(Boolean) as Revlog[]
 
-    const stats = getMemorisedDays(
-        revlogs,
-        [{ ...card.card(), did: 1, data: "{}" } as any],
-        configs,
-        mappings
-    )
+    const stats = getMemorisedDays(revlogs, [{
+        ...card.card(),
+        did: 1,
+        data: "{}",
+    } as any], configs, mappings)
 
     const retrievabilityValues = (stats.time_by_retrievability_mean ?? []).filter((v) =>
         Number.isFinite(v)

--- a/test/memorised.test.ts
+++ b/test/memorised.test.ts
@@ -1,27 +1,57 @@
-import { RevlogBuilder } from "./revlogBuilder"
-import {getMemorisedDays} from "../src/ts/MemorisedBar"
-import type {DeckConfig} from "../src/ts/config"
+import { fsrs } from "ts-fsrs"
+import { getMemorisedDays } from "../src/ts/MemorisedBar"
+import type { DeckConfig } from "../src/ts/config"
 import { Revlog } from "../src/ts/search"
-import {fsrs} from "ts-fsrs"
+import { RevlogBuilder } from "./revlogBuilder"
 
 const weights = [
-    0.40255, 1.18385, 3.173, 15.69105, 7.1949, 0.5345, 1.4604, 0.0046, 1.54575, 0.1192, 1.01925,
-    1.9395, 0.11, 0.29605, 2.2698, 0.2315, 2.9898, 0.51655, 0.6621, // Defaults
+    0.40255,
+    1.18385,
+    3.173,
+    15.69105,
+    7.1949,
+    0.5345,
+    1.4604,
+    0.0046,
+    1.54575,
+    0.1192,
+    1.01925,
+    1.9395,
+    0.11,
+    0.29605,
+    2.2698,
+    0.2315,
+    2.9898,
+    0.51655,
+    0.6621, // Defaults
 ]
 const weights2 = [
-    1, 100, 100, 100, 7.1949, 0.5345, 1.4604, 0.0046, 1.54575, 0.1192, 1.01925,
-    1.9395, 0.11, 0.29605, 2.2698, 0.2315, 2.9898 // on initial good: 100, no intra-day
+    1,
+    100,
+    100,
+    100,
+    7.1949,
+    0.5345,
+    1.4604,
+    0.0046,
+    1.54575,
+    0.1192,
+    1.01925,
+    1.9395,
+    0.11,
+    0.29605,
+    2.2698,
+    0.2315,
+    2.9898, // on initial good: 100, no intra-day
 ]
 
-const mappings = {1: 1, 2: 2}
+const mappings = { 1: 1, 2: 2 }
 const configs: Record<number, Partial<DeckConfig>> = {
-    1: {id: 1, fsrsWeights: weights, fsrsParams5: weights},
-    2: {id: 2, fsrsWeights: weights2, fsrsParams5: weights2}
+    1: { id: 1, fsrsWeights: weights, fsrsParams5: weights },
+    2: { id: 2, fsrsWeights: weights2, fsrsParams5: weights2 },
 }
 
-
-
-test("Day Timings", ()=>{
+test("Day Timings", () => {
     const card = new RevlogBuilder()
 
     const revlogs = [
@@ -32,13 +62,18 @@ test("Day Timings", ()=>{
         card.review(20, 3),
     ] as Revlog[]
 
-    const memorised = getMemorisedDays(revlogs, [{
-        ...card.card(),
-        did: 1
-    } as any],
-    configs,
-    mappings).retrievabilityDays
-    
+    const memorised = getMemorisedDays(
+        revlogs,
+        [
+            {
+                ...card.card(),
+                did: 1,
+            } as any,
+        ],
+        configs,
+        mappings
+    ).retrievabilityDays
+
     expect(memorised.length).not.toBe(0)
     expect(memorised[0]).toBe(1)
     expect(memorised[5]).toBe(1)
@@ -47,9 +82,9 @@ test("Day Timings", ()=>{
 })
 
 // https://github.com/open-spaced-repetition/fsrs-rs/blob/a7aaa40498bae992e0be0a1e9a1380e4992aee60/src/inference.rs#L433-L465
-test("Stability", ()=>{
+test("Stability", () => {
     const card = new RevlogBuilder()
-    const FSRS = fsrs({w: weights})
+    const FSRS = fsrs({ w: weights })
 
     const revlogs = [
         card.review(1, 1),
@@ -58,22 +93,28 @@ test("Stability", ()=>{
         card.review(80, 3),
     ] as Revlog[]
 
-    const memorised = getMemorisedDays(revlogs, [{
-        ...card.card(),
-        did: 1
-    } as any],
-    configs,
-    mappings).retrievabilityDays
+    const memorised = getMemorisedDays(
+        revlogs,
+        [
+            {
+                ...card.card(),
+                did: 1,
+            } as any,
+        ],
+        configs,
+        mappings
+    ).retrievabilityDays
 
     const OFFSET = 10
 
-    expect(memorised[card.last_review + OFFSET]).toBeCloseTo(FSRS.forgetting_curve(OFFSET, 31.722975))
-
+    expect(memorised[card.last_review + OFFSET]).toBeCloseTo(
+        FSRS.forgetting_curve(OFFSET, 31.722975)
+    )
 })
 
-test("Stability On Forget", ()=>{
+test("Stability On Forget", () => {
     const card = new RevlogBuilder()
-    const FSRS = fsrs({w: weights})
+    const FSRS = fsrs({ w: weights })
 
     const revlogs = [
         card.review(1, 1),
@@ -85,34 +126,74 @@ test("Stability On Forget", ()=>{
         card.review(80, 3),
     ] as Revlog[]
 
-    const memorised = getMemorisedDays(revlogs, [{
-        ...card.card(),
-        did: 1
-    } as any],
-    configs,
-    mappings).retrievabilityDays
+    const memorised = getMemorisedDays(
+        revlogs,
+        [
+            {
+                ...card.card(),
+                did: 1,
+            } as any,
+        ],
+        configs,
+        mappings
+    ).retrievabilityDays
 
     const OFFSET = 10
 
-    expect(memorised[card.last_review + OFFSET]).toBeCloseTo(FSRS.forgetting_curve(OFFSET, 31.722975))
-
+    expect(memorised[card.last_review + OFFSET]).toBeCloseTo(
+        FSRS.forgetting_curve(OFFSET, 31.722975)
+    )
 })
 
-test("Leech Detection", () =>{
+test("Leech Detection", () => {
     const card = new RevlogBuilder()
-    
-    const revlogs = [
-        card.review(-100, 3),
-        card.review(100, 3),
-        card.review(100, 1)
-    ] as Revlog[]
 
-    const leech_probabilities = getMemorisedDays(revlogs, [{
-        ...card.card(),
-        did: 2
-    } as any],
-    configs,
-    mappings, [], 1, 0).leech_probabilities
+    const revlogs = [card.review(-100, 3), card.review(100, 3), card.review(100, 1)] as Revlog[]
+
+    const leech_probabilities = getMemorisedDays(
+        revlogs,
+        [
+            {
+                ...card.card(),
+                did: 2,
+            } as any,
+        ],
+        configs,
+        mappings,
+        [],
+        1,
+        0
+    ).leech_probabilities
 
     expect(leech_probabilities[card.card().id]).toBeCloseTo(0.1)
+})
+
+test("Time distribution by retrievability and stability is generated", () => {
+    const card = new RevlogBuilder()
+
+    const revlogs = [
+        card.review(0, 3, 1000),
+        card.review(1, 3, 2000),
+        card.wait(2 * 24 * 60 * 60 * 1000),
+        card.review(2, 3, 4000),
+        card.wait(2 * 24 * 60 * 60 * 1000),
+        card.review(3, 2, 6000),
+    ].filter(Boolean) as Revlog[]
+
+    const stats = getMemorisedDays(
+        revlogs,
+        [{ ...card.card(), did: 1, data: "{}" } as any],
+        configs,
+        mappings
+    )
+
+    const retrievabilityValues = (stats.time_by_retrievability_mean ?? []).filter((v) =>
+        Number.isFinite(v)
+    )
+    const stabilityValues = (stats.time_by_stability_mean ?? []).filter((v) => Number.isFinite(v))
+
+    expect(retrievabilityValues.length).toBeGreaterThan(0)
+    expect(stabilityValues.length).toBeGreaterThan(0)
+    expect(Math.max(...retrievabilityValues)).toBeGreaterThan(0)
+    expect(Math.max(...stabilityValues)).toBeGreaterThan(0)
 })

--- a/test/revlog.test.ts
+++ b/test/revlog.test.ts
@@ -1,12 +1,16 @@
 import { DeltaIfy } from "../src/ts/Candlestick"
+import {
+    averageDecay,
+    buildForgettingCurve,
+    computeStabilityForSeries,
+} from "../src/ts/forgettingCurveData"
 import { calculateRevlogStats, day_ms } from "../src/ts/revlogGraphs"
 import type { Revlog } from "../src/ts/search"
 import { RevlogBuilder } from "./revlogBuilder"
-import { averageDecay, buildForgettingCurve, computeStabilityForSeries } from "../src/ts/forgettingCurveData"
 
 const burden_revlog_builder1 = new RevlogBuilder()
 const burden_revlog_builder2 = new RevlogBuilder()
-const burden_revlogs : Revlog[] = [
+const burden_revlogs: Revlog[] = [
     burden_revlog_builder1.review(-5000, 3),
     burden_revlog_builder1.review(-6000, 3),
     burden_revlog_builder1.review(1, 3),
@@ -18,11 +22,11 @@ const burden_revlogs : Revlog[] = [
     burden_revlog_builder1.review(1, 3),
     burden_revlog_builder1.review(4, 3),
 
-    burden_revlog_builder2.wait(7*day_ms),
+    burden_revlog_builder2.wait(7 * day_ms),
     burden_revlog_builder2.review(1) as Revlog,
-    burden_revlog_builder2.wait(2*day_ms),
-    burden_revlog_builder2.review(-5000) as Revlog, 
-].filter(a=>a) as Revlog[]
+    burden_revlog_builder2.wait(2 * day_ms),
+    burden_revlog_builder2.review(-5000) as Revlog,
+].filter((a) => a) as Revlog[]
 
 //Card1: 1, 0.5, 0.5, 0, 0, 1, 0.25, 0.25, 0.25, 0.25 0.25
 //Card2: 0, 0,   0,   0, 0, 0, 0,    1,    1,    1    1(learning)
@@ -31,22 +35,22 @@ const burden_revlogs : Revlog[] = [
 // console.log(burden_revlogs.map(revlog=>({id: revlog.id / day_ms, ...revlog})))
 
 const end = 10
-const {burden, learn_steps_per_card} = calculateRevlogStats(burden_revlogs, [burden_revlog_builder1.card(), burden_revlog_builder2.card()] as any, end)
-const fsrs_weights = [
-    0.40255, 1.18385, 3.173, 15.69105, 7.1949, 0.5345, 1.4604, 0.0046, 1.54575, 0.1192,
-    1.01925, 1.9395, 0.11, 0.29605, 2.2698, 0.2315, 2.9898, 0.51655, 0.6621,
-]
+const { burden, learn_steps_per_card } = calculateRevlogStats(
+    burden_revlogs,
+    [burden_revlog_builder1.card(), burden_revlog_builder2.card()] as any,
+    end
+)
 
-test("Burden", () =>{
+test("Burden", () => {
     // expect(burden.length).toEqual(end + 1)
     expect(burden).toMatchObject([1, 0.5, 0.5, 0, 0, 1, 0.25, 1.25, 1.25, 1.25, 1.25])
 })
 
-test("Burden delta", () =>{
+test("Burden delta", () => {
     expect(DeltaIfy(burden)).toMatchObject([1, -0.5, 0, -0.5, 0, 1, -0.75, 1, 0, 0, 0])
 })
 
-test("learn_step_count", ()=>{
+test("learn_step_count", () => {
     console.log(burden_revlogs)
     expect(learn_steps_per_card).toContain(2)
 })
@@ -78,54 +82,4 @@ test("Forgetting curve aggregates recall data", () => {
     expect(series?.points.length).toBeGreaterThan(0)
     expect(series?.stability).not.toBeNull()
     expect(stats.forgetting_curve_decay).toBeCloseTo(averageDecay([0.35]), 6)
-})
-
-test("Time distribution by retrievability and stability is generated", () => {
-    const previousSSEother = global.SSEother
-    try {
-        global.SSEother = {
-            ...previousSSEother,
-            deck_configs: {
-                1: {
-                    id: 1,
-                    fsrsParams6: [],
-                    fsrsWeights: fsrs_weights,
-                },
-            },
-            deck_config_ids: {
-                1: 1,
-            },
-            rollover: 0,
-        }
-
-        const builder = new RevlogBuilder()
-        const revlogs = [
-            builder.review(0, 3, 1000),
-            builder.review(1, 3, 2000),
-            builder.wait(2 * day_ms),
-            builder.review(2, 3, 4000),
-            builder.wait(2 * day_ms),
-            builder.review(3, 2, 6000),
-        ].filter(Boolean) as Revlog[]
-
-        const stats = calculateRevlogStats(
-            revlogs,
-            [{ ...builder.card(), did: 1, data: "{}" }] as any,
-            builder.last_review + 2
-        )
-
-        const retrievabilityValues = (stats.time_by_retrievability_mean ?? []).filter((v) =>
-            Number.isFinite(v)
-        )
-        const stabilityValues = (stats.time_by_stability_mean ?? []).filter((v) =>
-            Number.isFinite(v)
-        )
-
-        expect(retrievabilityValues.length).toBeGreaterThan(0)
-        expect(stabilityValues.length).toBeGreaterThan(0)
-        expect(Math.max(...retrievabilityValues)).toBeGreaterThan(0)
-        expect(Math.max(...stabilityValues)).toBeGreaterThan(0)
-    } finally {
-        global.SSEother = previousSSEother
-    }
 })

--- a/test/revlog.test.ts
+++ b/test/revlog.test.ts
@@ -88,7 +88,8 @@ test("Time distribution by retrievability and stability is generated", () => {
             deck_configs: {
                 1: {
                     id: 1,
-                    fsrsParams6: fsrs_weights,
+                    fsrsParams6: [],
+                    fsrsWeights: fsrs_weights,
                 },
             },
             deck_config_ids: {

--- a/test/revlog.test.ts
+++ b/test/revlog.test.ts
@@ -1,16 +1,12 @@
 import { DeltaIfy } from "../src/ts/Candlestick"
-import {
-    averageDecay,
-    buildForgettingCurve,
-    computeStabilityForSeries,
-} from "../src/ts/forgettingCurveData"
 import { calculateRevlogStats, day_ms } from "../src/ts/revlogGraphs"
 import type { Revlog } from "../src/ts/search"
 import { RevlogBuilder } from "./revlogBuilder"
+import { averageDecay, buildForgettingCurve, computeStabilityForSeries } from "../src/ts/forgettingCurveData"
 
 const burden_revlog_builder1 = new RevlogBuilder()
 const burden_revlog_builder2 = new RevlogBuilder()
-const burden_revlogs: Revlog[] = [
+const burden_revlogs : Revlog[] = [
     burden_revlog_builder1.review(-5000, 3),
     burden_revlog_builder1.review(-6000, 3),
     burden_revlog_builder1.review(1, 3),
@@ -22,11 +18,11 @@ const burden_revlogs: Revlog[] = [
     burden_revlog_builder1.review(1, 3),
     burden_revlog_builder1.review(4, 3),
 
-    burden_revlog_builder2.wait(7 * day_ms),
+    burden_revlog_builder2.wait(7*day_ms),
     burden_revlog_builder2.review(1) as Revlog,
-    burden_revlog_builder2.wait(2 * day_ms),
-    burden_revlog_builder2.review(-5000) as Revlog,
-].filter((a) => a) as Revlog[]
+    burden_revlog_builder2.wait(2*day_ms),
+    burden_revlog_builder2.review(-5000) as Revlog, 
+].filter(a=>a) as Revlog[]
 
 //Card1: 1, 0.5, 0.5, 0, 0, 1, 0.25, 0.25, 0.25, 0.25 0.25
 //Card2: 0, 0,   0,   0, 0, 0, 0,    1,    1,    1    1(learning)
@@ -35,22 +31,18 @@ const burden_revlogs: Revlog[] = [
 // console.log(burden_revlogs.map(revlog=>({id: revlog.id / day_ms, ...revlog})))
 
 const end = 10
-const { burden, learn_steps_per_card } = calculateRevlogStats(
-    burden_revlogs,
-    [burden_revlog_builder1.card(), burden_revlog_builder2.card()] as any,
-    end
-)
+const {burden, learn_steps_per_card} = calculateRevlogStats(burden_revlogs, [burden_revlog_builder1.card(), burden_revlog_builder2.card()] as any, end)
 
-test("Burden", () => {
+test("Burden", () =>{
     // expect(burden.length).toEqual(end + 1)
     expect(burden).toMatchObject([1, 0.5, 0.5, 0, 0, 1, 0.25, 1.25, 1.25, 1.25, 1.25])
 })
 
-test("Burden delta", () => {
+test("Burden delta", () =>{
     expect(DeltaIfy(burden)).toMatchObject([1, -0.5, 0, -0.5, 0, 1, -0.75, 1, 0, 0, 0])
 })
 
-test("learn_step_count", () => {
+test("learn_step_count", ()=>{
     console.log(burden_revlogs)
     expect(learn_steps_per_card).toContain(2)
 })

--- a/test/revlog.test.ts
+++ b/test/revlog.test.ts
@@ -32,6 +32,10 @@ const burden_revlogs : Revlog[] = [
 
 const end = 10
 const {burden, learn_steps_per_card} = calculateRevlogStats(burden_revlogs, [burden_revlog_builder1.card(), burden_revlog_builder2.card()] as any, end)
+const fsrs_weights = [
+    0.40255, 1.18385, 3.173, 15.69105, 7.1949, 0.5345, 1.4604, 0.0046, 1.54575, 0.1192,
+    1.01925, 1.9395, 0.11, 0.29605, 2.2698, 0.2315, 2.9898, 0.51655, 0.6621,
+]
 
 test("Burden", () =>{
     // expect(burden.length).toEqual(end + 1)
@@ -74,4 +78,53 @@ test("Forgetting curve aggregates recall data", () => {
     expect(series?.points.length).toBeGreaterThan(0)
     expect(series?.stability).not.toBeNull()
     expect(stats.forgetting_curve_decay).toBeCloseTo(averageDecay([0.35]), 6)
+})
+
+test("Time distribution by retrievability and stability is generated", () => {
+    const previousSSEother = global.SSEother
+    try {
+        global.SSEother = {
+            ...previousSSEother,
+            deck_configs: {
+                1: {
+                    id: 1,
+                    fsrsParams6: fsrs_weights,
+                },
+            },
+            deck_config_ids: {
+                1: 1,
+            },
+            rollover: 0,
+        }
+
+        const builder = new RevlogBuilder()
+        const revlogs = [
+            builder.review(0, 3, 1000),
+            builder.review(1, 3, 2000),
+            builder.wait(2 * day_ms),
+            builder.review(2, 3, 4000),
+            builder.wait(2 * day_ms),
+            builder.review(3, 2, 6000),
+        ].filter(Boolean) as Revlog[]
+
+        const stats = calculateRevlogStats(
+            revlogs,
+            [{ ...builder.card(), did: 1, data: "{}" }] as any,
+            builder.last_review + 2
+        )
+
+        const retrievabilityValues = (stats.time_by_retrievability_mean ?? []).filter((v) =>
+            Number.isFinite(v)
+        )
+        const stabilityValues = (stats.time_by_stability_mean ?? []).filter((v) =>
+            Number.isFinite(v)
+        )
+
+        expect(retrievabilityValues.length).toBeGreaterThan(0)
+        expect(stabilityValues.length).toBeGreaterThan(0)
+        expect(Math.max(...retrievabilityValues)).toBeGreaterThan(0)
+        expect(Math.max(...stabilityValues)).toBeGreaterThan(0)
+    } finally {
+        global.SSEother = previousSSEother
+    }
 })


### PR DESCRIPTION
Mostly made by Agent Codex, I tried to make it do the less code possible but there's the issue we need to store the R/S before review so it has to call forgetting_curve BEFORE the review is made and then your logic kicks in so the R/S post review is still there.

This gives those 2 new stats graph, pretty interesting to see if you are much slower at lower R or S

![CleanShot 2026-04-06 at 12 38 50](https://github.com/user-attachments/assets/43c043e8-a2af-4de8-923d-04b9aedaab7f)
