### PR TITLE
Fix: Ignore interval if the next review is a reset

### DIFF
--- a/src/ts/revlogGraphs.ts
+++ b/src/ts/revlogGraphs.ts
@@ -52,6 +52,10 @@ export function IDify<T extends { id: number }>(array: T[]) {
     return id_data
 }
 
+function isForget(revlog?: Revlog) {
+    return revlog && revlog.factor == 0 && revlog.type == 4
+}
+
 export function calculateRevlogStats(
     revlogData: Revlog[],
     cardData: CardData[],
@@ -183,7 +187,7 @@ export function calculateRevlogStats(
         } else {
             incrementAllEase("learn")
         }
-        if (revlog.factor == 0 && revlog.type == 4) {
+        if (isForget(revlog)) {
             introduced.delete(revlog.cid)
             forgotten.add(revlog.cid)
             last_forget[revlog.cid] = revlog.id
@@ -278,7 +282,7 @@ export function calculateRevlogStats(
         // If the card is still learning, use the card data
         let ivl = next_review ? revlog.ivl : card.type != 3 && card.type != 1 ? card.ivl : 0
         // Ignore "forgets"
-        if ((revlog.factor == 0 && revlog.type == 4) || (!next_review && card.queue == 0)) {
+        if (isForget(revlog) || isForget(next_review) || (!next_review && card.queue == 0)) {
             last_cids[revlog.cid] = revlog
             return undefined
         }

--- a/src/ts/revlogGraphs.ts
+++ b/src/ts/revlogGraphs.ts
@@ -88,6 +88,7 @@ export function calculateRevlogStats(
     let day_forgotten: number[] = emptyArray(0)
 
     let intervals: number[][] = []
+    let burden: number[] = []
 
     let day_initial_ease: number[][] = emptyArray(initialEase())
     let day_initial_reintroduced_ease: number[][] = emptyArray(initialEase())
@@ -282,7 +283,7 @@ export function calculateRevlogStats(
         // If the card is still learning, use the card data
         let ivl = next_review ? revlog.ivl : card.type != 3 && card.type != 1 ? card.ivl : 0
         // Ignore "forgets"
-        if (isForget(revlog) || isForget(next_review) || (!next_review && card.queue == 0)) {
+        if (isForget(revlog) || (!next_review && card.queue == 0)) {
             last_cids[revlog.cid] = revlog
             return undefined
         }
@@ -292,6 +293,9 @@ export function calculateRevlogStats(
         if (!next_review && card.queue == -1) {
             ivl = -1
         }
+
+        // load/burden
+        const is_load = !isForget(next_review) && ivl != -1
 
         let to = next_review ? dayFromMs(next_review.id) : end + 1
 
@@ -304,6 +308,10 @@ export function calculateRevlogStats(
             if (ivl == 0 && (revlog.type == 0 || (!next_review && card.type == 1))) {
                 intervals[intervalDay][-2] = (intervals[intervalDay][-2] ?? 0) + 1
             }
+
+            if (is_load) {
+                burden[intervalDay] = (burden[intervalDay] ?? 0) + (ivl > 0 ? 1 / ivl : 1)
+            }
         }
 
         last_cids[revlog.cid] = revlog
@@ -311,13 +319,8 @@ export function calculateRevlogStats(
         return undefined
     }, undefined)
 
-    const burden = Array.from(intervals).map((v) => {
-        if (!v) {
-            return 0
-        } else {
-            return _.sum(v.map((val, ivl) => val / (ivl || 1))) ?? 0
-        }
-    })
+    burden = Array.from(burden).map((a) => a ?? 0)
+    intervals = intervals.map((day) => Array.from(day ?? []).map((a) => a ?? 0))
 
     // Calculate current load by introduction day
     for (const card of cardData) {

--- a/test/revlog.test.ts
+++ b/test/revlog.test.ts
@@ -24,22 +24,25 @@ const burden_revlogs : Revlog[] = [
     burden_revlog_builder2.review(-5000) as Revlog, 
 ].filter(a=>a) as Revlog[]
 
-//Card1: 1, 0.5, 0.5, 0, 0, 1, 0.25, 0.25, 0.25, 0.25 0.25
-//Card2: 0, 0,   0,   0, 0, 0, 0,    1,    1,    1    1(learning)
-//Total: 1, 0.5, 0.5, 0, 0, 1, 0.25, 1.25, 1.25  1.25 1.25
-
 // console.log(burden_revlogs.map(revlog=>({id: revlog.id / day_ms, ...revlog})))
 
 const end = 10
-const {burden, learn_steps_per_card} = calculateRevlogStats(burden_revlogs, [burden_revlog_builder1.card(), burden_revlog_builder2.card()] as any, end)
+const {burden, intervals, learn_steps_per_card} = calculateRevlogStats(burden_revlogs, [burden_revlog_builder1.card(), burden_revlog_builder2.card()] as any, end)
+
+test("Intervals", () =>{
+    // In an ideal world these undefined would be [] but its hard to do with a sparse array that starts at not 0
+    expect(intervals).toMatchObject([
+        [0, 1], [0, 0, 1], [0, 0, 1], undefined, undefined, [0, 1], [0, 0, 0, 0, 1], [0, 1, 0, 0, 1], [0, 1, 0, 0, 1], [0, 1, 0, 0, 1], [1, 0, 0, 0, 1],
+    ])
+})
 
 test("Burden", () =>{
     // expect(burden.length).toEqual(end + 1)
-    expect(burden).toMatchObject([1, 0.5, 0.5, 0, 0, 1, 0.25, 1.25, 1.25, 1.25, 1.25])
+    expect(burden).toMatchObject([1, 0, 0, 0, 0, 1, 0.25, 1.25, 1.25, 1.25, 1.25])
 })
 
 test("Burden delta", () =>{
-    expect(DeltaIfy(burden)).toMatchObject([1, -0.5, 0, -0.5, 0, 1, -0.75, 1, 0, 0, 0])
+    expect(DeltaIfy(burden)).toMatchObject([1, -1, 0, 0, 0, 1, -0.75, 1, 0, 0, 0])
 })
 
 test("learn_step_count", ()=>{


### PR DESCRIPTION
Also removes the review prematurely from the "review intervals" graph sadly. Maybe the burden should be calculated separately.

https://github.com/Luc-Mcgrady/Anki-Search-Stats-Extended/blob/d173b37822b70c4259bbb5d02d9d8ecdbca3bd00/src/ts/revlogGraphs.ts#L314-L320