### PR TITLE
make it so crams don't count for load

### DIFF
--- a/locale/en_GB.ftl
+++ b/locale/en_GB.ftl
@@ -456,6 +456,7 @@ credits-Jarrett-Ye = Jarrett Ye: {memorised}, {forgetting-curve} and {first-shor
 credits-Ishiko = Ishiko: {memorised} graph
 credits-Rener-Crisostomo = Renêr Crisostomo: Brazilian translation
 credits-user1823 = user1823: Performance improvements
+credits-mikael = mikael2123: {load-trend} fix for cram reviews
 
 support = Support the Addon
 like-on-ankiweb = Like on AnkiWeb 👍

--- a/src/ts/About.svelte
+++ b/src/ts/About.svelte
@@ -18,6 +18,7 @@
             <li>{i18n("credits-Huili-fox")}</li>
             <li>{i18n("credits-Rener-Crisostomo")}</li>
             <li>{i18n("credits-user1823")}</li>
+            <li>{i18n("credits-mikael")}</li>
         </ul>
     </GraphContainer>
     <GraphContainer>

--- a/src/ts/revlogGraphs.ts
+++ b/src/ts/revlogGraphs.ts
@@ -56,6 +56,10 @@ function isForget(revlog?: Revlog) {
     return revlog && revlog.factor == 0 && revlog.type == 4
 }
 
+function isCram(revlog?: Revlog) {
+    return revlog && revlog.factor == 0 && revlog.type == 3
+}
+
 export function calculateRevlogStats(
     revlogData: Revlog[],
     cardData: CardData[],
@@ -282,6 +286,12 @@ export function calculateRevlogStats(
         const next_review = last_cids[revlog.cid]
         // If the card is still learning, use the card data
         let ivl = next_review ? revlog.ivl : card.type != 3 && card.type != 1 ? card.ivl : 0
+        // Filtered/cram reviews don't reschedule the card, so make them transparent:
+        // return WITHOUT updating last_cids, so the previous review's interval spans
+        // across the cram day instead of the cram injecting a 0-interval segment.
+        if (isCram(revlog)) {
+            return undefined
+        }
         // Ignore "forgets"
         if (isForget(revlog) || (!next_review && card.queue == 0)) {
             last_cids[revlog.cid] = revlog


### PR DESCRIPTION
Did the changes I mentioned in #111 to fix cram counting for load in historical load calculations. Tested this on my own anki deck and it perfectly tracks my manually recorded historical load data.

Closes #111.